### PR TITLE
Related Content 2.0

### DIFF
--- a/armstrong/apps/related_content/fields.py
+++ b/armstrong/apps/related_content/fields.py
@@ -74,7 +74,7 @@ class RelatedM2MDescriptor(object):
 
     def __set__(self, instance, value):
         raise NonAssignableError("RelatedFields cannot be used to assign "
-                " RelatedContent objects, use a RelatedContentField")
+                "RelatedContent objects, use a RelatedContentField")
 
 
 class RelatedObjectsField(object):


### PR DESCRIPTION
See the README.rst for a brief overview of the new API.

This PR breaks backwards compatibility with RelatedContent v1 and thus has a major version bump to 2.0. BC is broken in that I moved RelatedObjectsField into .fields from .models. Also the operation of RelatedObjectsField and ReverseRelatedObjectsField is updated so that they are read-only fields for accessing the objects that an object is related to as opposed to being just another way of accessing .models.RelatedContent objects

The big win from this PR is being able to use syntax like the following in templates :

```
{% render_model object.related.lead_art.0 'lead_art' %}
```
